### PR TITLE
Include SIGHUP SIGINT in default signals

### DIFF
--- a/src/factories/createLightship.js
+++ b/src/factories/createLightship.js
@@ -22,7 +22,9 @@ const log = Logger.child({
 const defaultConfiguration = {
   port: 9000,
   signals: [
-    'SIGTERM'
+    'SIGTERM',
+    'SIGHUP',
+    'SIGINT'
   ]
 };
 


### PR DESCRIPTION
In production, it makes sense to catch the only SIGTERM but for development, it makes sense that ctrl+c should mimic the same behaviour. Of course this configurable but it should be the default.

SIGHUP
SIGINT