### PR TITLE
Fix delay module missing as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     ]
   },
   "dependencies": {
+    "delay": "^4.3.0",
     "express": "^4.17.1",
     "roarr": "^2.13.2",
     "serialize-error": "^4.1.0"
@@ -35,7 +36,6 @@
     "axios": "^0.19.0",
     "babel-plugin-istanbul": "^5.1.4",
     "coveralls": "^3.0.5",
-    "delay": "^4.3.0",
     "eslint": "^6.0.1",
     "eslint-config-canonical": "^17.1.4",
     "flow-bin": "^0.103.0",

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -3,5 +3,5 @@
 import Roarr from 'roarr';
 
 export default Roarr.child({
-  package: 'lightship'
+  package: 'lightship',
 });

--- a/src/factories/createLightship.js
+++ b/src/factories/createLightship.js
@@ -10,20 +10,20 @@ import type {
   ConfigurationType,
   LightshipType,
   ShutdownHandlerType,
-  UserConfigurationType
+  UserConfigurationType,
 } from '../types';
 import {
   SERVER_IS_NOT_READY,
   SERVER_IS_NOT_SHUTTING_DOWN,
   SERVER_IS_READY,
-  SERVER_IS_SHUTTING_DOWN
+  SERVER_IS_SHUTTING_DOWN,
 } from '../states';
 import {
-  isKubernetes
+  isKubernetes,
 } from '../utilities';
 
 const log = Logger.child({
-  namespace: 'factories/createLightship'
+  namespace: 'factories/createLightship',
 });
 
 const defaultConfiguration = {
@@ -32,9 +32,9 @@ const defaultConfiguration = {
   signals: [
     'SIGTERM',
     'SIGHUP',
-    'SIGINT'
+    'SIGINT',
   ],
-  timeout: 60000
+  timeout: 60000,
 };
 
 export default (userConfiguration?: UserConfigurationType): LightshipType => {
@@ -46,7 +46,7 @@ export default (userConfiguration?: UserConfigurationType): LightshipType => {
 
   const configuration: ConfigurationType = {
     ...defaultConfiguration,
-    ...userConfiguration
+    ...userConfiguration,
   };
 
   let serverIsReady = false;
@@ -141,7 +141,7 @@ export default (userConfiguration?: UserConfigurationType): LightshipType => {
         const check = () => {
           if (beacons.length > 0) {
             log.info({
-              beacons
+              beacons,
             }, 'program termination is on hold because there are live beacons');
           } else {
             resolve();
@@ -161,7 +161,7 @@ export default (userConfiguration?: UserConfigurationType): LightshipType => {
         await shutdownHandler();
       } catch (error) {
         log.error({
-          error: serializeError(error)
+          error: serializeError(error),
         }, 'shutdown handler produced an error');
       }
     }
@@ -171,7 +171,7 @@ export default (userConfiguration?: UserConfigurationType): LightshipType => {
     server.close((error) => {
       if (error) {
         log.error({
-          error: serializeError(error)
+          error: serializeError(error),
         }, 'server was terminated with an error');
       }
 
@@ -193,7 +193,7 @@ export default (userConfiguration?: UserConfigurationType): LightshipType => {
     for (const signal of configuration.signals) {
       process.on(signal, () => {
         log.debug({
-          signal
+          signal,
         }, 'received a shutdown signal');
 
         shutdown();
@@ -203,7 +203,7 @@ export default (userConfiguration?: UserConfigurationType): LightshipType => {
 
   const createBeacon = (context) => {
     const beacon = {
-      context: context || {}
+      context: context || {},
     };
 
     beacons.push(beacon);
@@ -211,7 +211,7 @@ export default (userConfiguration?: UserConfigurationType): LightshipType => {
     return {
       die: async () => {
         log.trace({
-          beacon
+          beacon,
         }, 'beacon has been killed');
 
         beacons.splice(beacons.indexOf(beacon), 1);
@@ -219,7 +219,7 @@ export default (userConfiguration?: UserConfigurationType): LightshipType => {
         eventEmitter.emit('beaconStateChange');
 
         await delay(0);
-      }
+      },
     };
   };
 
@@ -237,6 +237,6 @@ export default (userConfiguration?: UserConfigurationType): LightshipType => {
     server,
     shutdown,
     signalNotReady,
-    signalReady
+    signalReady,
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,5 @@
 
 export {default as createLightship} from './factories/createLightship';
 export type {
-  LightshipType
+  LightshipType,
 } from './types';

--- a/src/states.js
+++ b/src/states.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {
-  StateType
+  StateType,
 } from './types';
 
 const createState = (subject: *): StateType => {

--- a/src/types.js
+++ b/src/types.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {
-  Server
+  Server,
 } from 'http';
 
 /**

--- a/test/factories/createLightship.js
+++ b/test/factories/createLightship.js
@@ -2,7 +2,7 @@
 
 import test, {
   afterEach,
-  beforeEach
+  beforeEach,
 } from 'ava';
 import sinon from 'sinon';
 import delay from 'delay';
@@ -12,7 +12,7 @@ import {
   SERVER_IS_NOT_READY,
   SERVER_IS_NOT_SHUTTING_DOWN,
   SERVER_IS_READY,
-  SERVER_IS_SHUTTING_DOWN
+  SERVER_IS_SHUTTING_DOWN,
 } from '../../src/states';
 
 type ProbeStateType = {|
@@ -30,34 +30,34 @@ const getServiceState = async (port: number = 9000): Promise<ServiceStateType> =
   const health = await axios('http://127.0.0.1:' + port + '/health', {
     validateStatus: () => {
       return true;
-    }
+    },
   });
 
   const live = await axios('http://127.0.0.1:' + port + '/live', {
     validateStatus: () => {
       return true;
-    }
+    },
   });
 
   const ready = await axios('http://127.0.0.1:' + port + '/ready', {
     validateStatus: () => {
       return true;
-    }
+    },
   });
 
   return {
     health: {
       message: health.data,
-      status: health.status
+      status: health.status,
     },
     live: {
       message: live.data,
-      status: live.status
+      status: live.status,
     },
     ready: {
       message: ready.data,
-      status: ready.status
-    }
+      status: ready.status,
+    },
   };
 };
 


### PR DESCRIPTION
When running lightship in production mode the `delay` module is missing. Having a look I found out that it has been imported as `devDependency`.

This PR moves it to the right place

```
Error: Cannot find module 'delay'
Require stack:
- /Users/wneto/Dev/node-docker-example/node_modules/lightship/dist/factories/createLightship.js
- /Users/wneto/Dev/node-docker-example/node_modules/lightship/dist/index.js
```