### PR TITLE
Correct sentence about how beacons block shutdowns.

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -316,7 +316,7 @@ const beacon = lightship.createBeacon();
 
 ```
 
-Beacon is live upon creation. Shutdown handlers are suspended until there are live beacons.
+Beacon is live upon creation. Shutdown handlers are suspended until there are no live beacons.
 
 To singnal that a beacon is dead, use `die()` method:
 


### PR DESCRIPTION
Correcting the documentation on beacons, I believe that this sentence is missing the key word 'no'

