### PR TITLE
fix: rejections in blocking task causing unhandled promise rejections

### DIFF
--- a/test/lightship/factories/createLightship.ts
+++ b/test/lightship/factories/createLightship.ts
@@ -440,3 +440,32 @@ test('delays shutdown handlers', async (t) => {
   t.is(terminate.called, false);
 });
 
+test('errors produced by blocking tasks causes a service shutdown', async (t) => {
+  const terminate = stub();
+
+  const lightship = createLightship({
+    shutdownDelay: 0,
+    terminate,
+  });
+
+  let rejectBlockingTask: (() => void) | undefined;
+
+  const blockingTask = new Promise<void>((resolve, reject) => {
+    rejectBlockingTask = reject;
+  });
+
+  lightship.queueBlockingTask(blockingTask);
+
+  lightship.signalReady();
+
+  t.is(lightship.isServerReady(), false);
+
+  if (rejectBlockingTask) {
+    rejectBlockingTask();
+  }
+
+  await delay(0);
+
+  t.is(lightship.isServerShuttingDown(), true);
+  t.is(lightship.isServerReady(), false);
+});


### PR DESCRIPTION
Promise rejections from blocked tasks are causing `UnhandledPromiseRejectionWarning` warnings.

### Steps to reproduce
```
const lightship = require('lightship').createLightship()

lightship.queueBlockingTask(new Promise((resolve, reject) => {
  setTimeout(() => reject('rejected'), 500);
}));

lightship.signalReady();

lightship.whenFirstReady()
  .catch((error) => console.error('fail', error));
```

### Output
```
> (node:71458) UnhandledPromiseRejectionWarning: rejected
(Use `node --trace-warnings ...` to show where the warning was created)
(node:71458) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:71458) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

### Fix
```
> fail rejected
```
