### PR TITLE
feat: Update `fastify` to expose API for `HEAD` requests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - node
   - 14
 script:
   - npm run lint

--- a/src/factories/createLightship.ts
+++ b/src/factories/createLightship.ts
@@ -99,7 +99,9 @@ export default async (userConfiguration?: ConfigurationInput): Promise<Lightship
     return serverIsReady;
   };
 
-  const app = createFastify({ exposeHeadRoutes: true });
+  const app = createFastify({
+    exposeHeadRoutes: true,
+  });
 
   app.addHook('onError', (request, reply, error, done) => {
     // Only send Sentry errors when not in development

--- a/src/factories/createLightship.ts
+++ b/src/factories/createLightship.ts
@@ -99,7 +99,7 @@ export default async (userConfiguration?: ConfigurationInput): Promise<Lightship
     return serverIsReady;
   };
 
-  const app = createFastify();
+  const app = createFastify({ exposeHeadRoutes: true });
 
   app.addHook('onError', (request, reply, error, done) => {
     // Only send Sentry errors when not in development

--- a/test/lightship/factories/createLightship.ts
+++ b/test/lightship/factories/createLightship.ts
@@ -35,19 +35,28 @@ const getLightshipPort = (lightship: Lightship) => {
   return address.port;
 };
 
-function getServiceState(lightship: Lightship, method: 'GET'): Promise<ServiceState>;
-function getServiceState(lightship: Lightship, method: 'HEAD'): Promise<ServiceState<Pick<ProbeState, 'status'>>>;
-async function getServiceState(lightship: Lightship, method: 'GET' | 'HEAD'): Promise<ServiceState<ProbeState | Pick<ProbeState, 'status'>>> {
-
+function getServiceState (lightship: Lightship, method: 'GET'): Promise<ServiceState>;
+function getServiceState (lightship: Lightship, method: 'HEAD'): Promise<ServiceState<Pick<ProbeState, 'status'>>>;
+async function getServiceState (lightship: Lightship, method: 'GET' | 'HEAD'): Promise<ServiceState<Pick<ProbeState, 'status'> | ProbeState>> {
   const port = getLightshipPort(lightship);
-  const baseURL = `http://127.0.0.1:${port}`
-  const baseAxios = axios.create({ baseURL, validateStatus: () => true, method })
+  const baseURL = `http://127.0.0.1:${port}`;
+  const baseAxios = axios.create({
+    baseURL,
+    method,
+    validateStatus: () => {
+      return true;
+    },
+  });
 
-  const [health, live, ready] = await Promise.all([
+  const [
+    health,
+    live,
+    ready,
+  ] = await Promise.all([
     baseAxios('/health'),
     baseAxios('/live'),
     baseAxios('/ready'),
-  ])
+  ]);
 
   if (method === 'GET') {
     return {
@@ -67,7 +76,7 @@ async function getServiceState(lightship: Lightship, method: 'GET' | 'HEAD'): Pr
   } else {
     return {
       health: {
-        status: health.status
+        status: health.status,
       },
       live: {
         status: live.status,
@@ -75,11 +84,9 @@ async function getServiceState(lightship: Lightship, method: 'GET' | 'HEAD'): Pr
       ready: {
         status: ready.status,
       },
-    }
+    };
   }
-
-
-};
+}
 
 test('server starts in SERVER_IS_NOT_READY state', async (t) => {
   const terminate = stub();
@@ -147,13 +154,12 @@ test('server responds to HEAD requests', async (t) => {
 
   lightship.signalReady();
 
-  const state = await getServiceState(lightship, 'HEAD')
+  const state = await getServiceState(lightship, 'HEAD');
 
-  t.is(state.health.status, 200)
-  t.is(state.health.status, 200)
-  t.is(state.health.status, 200)
-
-})
+  t.is(state.health.status, 200);
+  t.is(state.health.status, 200);
+  t.is(state.health.status, 200);
+});
 
 test('returns service state multiple time', async (t) => {
   const terminate = stub();

--- a/test/lightship/factories/createLightship.ts
+++ b/test/lightship/factories/createLightship.ts
@@ -37,6 +37,7 @@ const getLightshipPort = (lightship: Lightship) => {
 
 function getServiceState (lightship: Lightship, method: 'GET'): Promise<ServiceState>;
 function getServiceState (lightship: Lightship, method: 'HEAD'): Promise<ServiceState<Pick<ProbeState, 'status'>>>;
+// eslint-disable-next-line func-style
 async function getServiceState (lightship: Lightship, method: 'GET' | 'HEAD'): Promise<ServiceState<Pick<ProbeState, 'status'> | ProbeState>> {
   const port = getLightshipPort(lightship);
   const baseURL = `http://127.0.0.1:${port}`;


### PR DESCRIPTION
This patch enables a fastify config to enable `HEAD` requests. Readiness and liveness checks should respond correctly to `HEAD` requests since only the status codes are usually relevant for checking the status of services via tools like curl.

Eg:

https://hub.docker.com/r/stefanevinance/wait-for-200/
https://github.com/stefan-evinance/wait-for-200

Tests have been updated to verify this behaviour.